### PR TITLE
Fix uninstall check in Package

### DIFF
--- a/packages/core/src/Package.ts
+++ b/packages/core/src/Package.ts
@@ -40,7 +40,7 @@ export default abstract class Package<TConfig extends PackageConfig = PackageCon
   protected abstract installPackage(): Promise<void>;
 
   async uninstall() {
-    if (await this.isInstalled()) {
+    if (!(await this.isInstalled())) {
       this.log('Not installed');
       return;
     }


### PR DESCRIPTION
## Summary
- fix uninstall() to only log "Not installed" when the package isn't installed

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dad31f7c83238b9bdc54abdd9eaa