### PR TITLE
Fix variable name in Env spec

### DIFF
--- a/packages/env/src/Env.spec.ts
+++ b/packages/env/src/Env.spec.ts
@@ -34,8 +34,8 @@ describe('Env Module', () => {
     expect(printEnvFromSystem).toBeUndefined();
 
     await env.unset('TEST_VAR');
-    const unsetedValue = await env.get('TEST_VAR');
-    expect(unsetedValue).toBeUndefined();
+    const unsetValue = await env.get('TEST_VAR');
+    expect(unsetValue).toBeUndefined();
 
     const printEnvFromSystem2 = await env.connection.cmd({}).getEnv('TEST_VAR', true); //(await env.$`printf "%s" $TEST_VAR`.text()) || undefined;
     expect(printEnvFromSystem2).toBeUndefined();


### PR DESCRIPTION
## Summary
- correct typo in Env.spec test variable name

## Testing
- `npm test` *(fails: cross-env: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842daefdefc8323bc797123b2ad5967